### PR TITLE
test: simplify and fix failing test

### DIFF
--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,8 +1,8 @@
-import { setupTest, get, getNuxt, generate } from '@nuxt/test-utils'
+import { setupTest, get, getNuxt } from '@nuxt/test-utils'
 import { resolve } from 'upath'
 import { readFile } from 'fs-extra'
 
-const rootDir = resolve(__dirname, '../example')
+const rootDir = './example'
 
 describe('module in server', () => {
   setupTest({
@@ -23,8 +23,7 @@ describe('module in server', () => {
   })
 })
 
-// TODO:
-describe.skip('module in generated pages', () => {
+describe('module in generated pages', () => {
   setupTest({
     rootDir,
     generate: true,
@@ -34,10 +33,7 @@ describe.skip('module in generated pages', () => {
   })
 
   it('enables extractCSS', async () => {
-    const nuxt = getNuxt()
-    const generatePath = nuxt.options.generate.dir
-    await generate()
-    const body = await readFile(join(generatePath, 'index.html'), 'utf-8')
+    const body = await readFile(resolve(rootDir, 'dist/index.html'), 'utf-8')
     expect(body).toContain('<style>')
     expect(body).toContain('.sample-class')
     expect(body).not.toContain('.sample-unused-class')


### PR DESCRIPTION
Noticed one skipped failing test here. Fixing it.

`await generate()` is timing out the test. There is no need to call it, because `generate: true` does [this job](https://github.com/nuxt/test-utils/blob/9b239ac1550118262440c20805ceca6fc69c14fc/src/setup.ts#L52-L54) already (and it is wrapped in a `test` block with longer timeout).

And a couple of simplifications:
- default generate directory is known in advance.
- the `rootDir` will be [resolved](https://github.com/nuxt/nuxt.js/blob/3e9d7e3e7cbdeb707e3aedc1bea7b24479361cba/packages/config/src/load.js#L18) inside Nuxt’s `loadNuxtConfig`.